### PR TITLE
Add CORS Middleware

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
 from endpoints import user, role, customer, bid, project
 
 app = FastAPI()
@@ -7,6 +9,19 @@ app.include_router(role.router)
 app.include_router(customer.router)
 app.include_router(bid.router)
 app.include_router(project.router)
+
+origins = [
+    "http://localhost:5173",
+    # TODO - add deployed app url to allow traffic from it
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/")


### PR DESCRIPTION
This is just a quick PR fixing a CORS issue when calling API endpoints from the frontend

Eventually I think we'll need to add the deployed frontend URL whenever we get to that